### PR TITLE
Resolved quit segfault issue

### DIFF
--- a/House.cpp
+++ b/House.cpp
@@ -14,7 +14,11 @@ Houses::Houses()
     head->neighborhood = "cheyenne mountain";
     head->price = 50000;
     head->previous = NULL;
-    head->next = tail;
+    //head->next = tail; Note: defining the head->next = tail here will
+    //result in a seg fault. The head->next is being set to a place in
+    //memory that isnt really there yet. To fix the seg fault when quitting
+    //issue I mentioned, I moved this line of code to line 33. Which sets
+    //the head->next to tail which is now a defined spot in memory.
 
     tail = new house;
     tail->address = 277;
@@ -27,6 +31,7 @@ Houses::Houses()
     tail->price = 450000;
     tail->next = NULL;
     tail->previous = head;
+    head->next = tail;
 }
 
 Houses::~Houses()

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ Group Members:
 Rachel Lewis
 
 Contributors:
-Not sure who the contributors will be yet.
+Michael Condon (SuperialCondon)
 
 Open Issues/Bugs:
 I will figure this out when I write my program and test it.
+**Resolved**: If the user initially selects the quit option without doing anything else, the program prints the address of the head and then seg-faults. For example: Menu displays, user enters "7" for quit, prints "1058 virgor", then seg faults.
+		Fixed by changing the head->next pointer in the house constructor


### PR DESCRIPTION
I fixed the issue I mentioned earlier with the quit option seg faulting. It was located in the House constructor. I left comments about what exactly I did.
